### PR TITLE
fix pkg install path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ For generating exported Gerbil names.
 ## Installation
 
 ```
-gxpkg install thunknyc/apropos
+gxpkg install github.com/thunknyc/apropos
 ```
 
 ## Useful procedures
 
 * `apropos-re re-str [apropos-db]`
 * `apropos string-or-symbol [apropos-db]`
-* `module-exports module-symbol`
 * `build-apropos-db`


### PR DESCRIPTION
also removes module-exports from the procedure list, as it's not exported.